### PR TITLE
Add stricter ruff linting rules

### DIFF
--- a/dissect/extfs/__init__.py
+++ b/dissect/extfs/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dissect.extfs.exceptions import (
     Error,
     FileNotFoundError,

--- a/dissect/extfs/exceptions.py
+++ b/dissect/extfs/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class Error(Exception):
     pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ select = [
   "SLOT",
   "SIM",
   "TID",
-  "TCH",
+  "TC",
   "PTH",
   "PLC",
   "TRY",
@@ -102,8 +102,25 @@ select = [
   "PERF",
   "FURB",
   "RUF",
+  "D"
 ]
-ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003"]
+ignore = [
+    "E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003", "PLC0415",
+    # Ignore some pydocstyle rules for now as they require a larger cleanup
+    "D1",
+    "D205",
+    "D301",
+    "D417",
+    # Seems bugged: https://github.com/astral-sh/ruff/issues/16824
+    "D402",
+]
+future-annotations = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-type-checking]
+strict = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/_docs/**" = ["INP001"]
@@ -111,6 +128,7 @@ ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM1
 [tool.ruff.lint.isort]
 known-first-party = ["dissect.extfs"]
 known-third-party = ["dissect"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.setuptools.packages.find]
 include = ["dissect.*"]

--- a/tests/_docs/conf.py
+++ b/tests/_docs/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 extensions = [
     "autoapi.extension",
     "sphinx.ext.autodoc",


### PR DESCRIPTION
Code changes are only addition of `from __future__ import annotations`, this suggest to not add this commit to git-ignore-blame

  * fixes #50
